### PR TITLE
Fix gettext() for 'summaryCredibleIntervalWidth'

### DIFF
--- a/R/prophet.R
+++ b/R/prophet.R
@@ -478,7 +478,7 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
 
     criLevel <- (1-options[["summaryCredibleIntervalWidth"]])/2
 
-    overtitle <- gettext(paste0(options[["summaryCredibleIntervalWidth"]]*100, "% CI"))
+    overtitle <- paste0(options[["summaryCredibleIntervalWidth"]]*100, "% CI")
     prophetTable$addColumnInfo(name = "par", title = gettext("Parameter"), type = "string")
     prophetTable$addColumnInfo(name = "mean", title = gettext("Mean"), type = "number")
     prophetTable$addColumnInfo(name = "sd", title = gettext("SD"), type = "number")
@@ -556,7 +556,7 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
     prophetTable$addColumnInfo(name = "delta", title = gettext("Change in growth rate (\u03B4)"), type = "number")
   } else {
     parTitle <- gettext("Change in growth rate (\u03B4)")
-    ciTitle  <- gettext(paste0(options[["summaryCredibleIntervalWidth"]]*100, "% CI"))
+    ciTitle  <- paste0(options[["summaryCredibleIntervalWidth"]]*100, "% CI")
     prophetTable$addColumnInfo(name = "mean", title = gettext("Mean"), type = "number", overtitle = parTitle)
     prophetTable$addColumnInfo(name = "sd", title = gettext("SD"), type = "number", overtitle = parTitle)
     prophetTable$addColumnInfo(name = "lowerCri", title = gettext("Lower"), type = "number", overtitle = ciTitle)

--- a/R/prophet.R
+++ b/R/prophet.R
@@ -478,7 +478,7 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
 
     criLevel <- (1-options[["summaryCredibleIntervalWidth"]])/2
 
-    overtitle <- paste0(options[["summaryCredibleIntervalWidth"]]*100, "% CI")
+    overtitle <- gettextf("%s%% CI", options[["summaryCredibleIntervalWidth"]]*100)
     prophetTable$addColumnInfo(name = "par", title = gettext("Parameter"), type = "string")
     prophetTable$addColumnInfo(name = "mean", title = gettext("Mean"), type = "number")
     prophetTable$addColumnInfo(name = "sd", title = gettext("SD"), type = "number")

--- a/R/prophet.R
+++ b/R/prophet.R
@@ -556,7 +556,7 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
     prophetTable$addColumnInfo(name = "delta", title = gettext("Change in growth rate (\u03B4)"), type = "number")
   } else {
     parTitle <- gettext("Change in growth rate (\u03B4)")
-    ciTitle  <- paste0(options[["summaryCredibleIntervalWidth"]]*100, "% CI")
+    ciTitle  <- gettextf("%s%% CI", options[["summaryCredibleIntervalWidth"]]*100)
     prophetTable$addColumnInfo(name = "mean", title = gettext("Mean"), type = "number", overtitle = parTitle)
     prophetTable$addColumnInfo(name = "sd", title = gettext("SD"), type = "number", overtitle = parTitle)
     prophetTable$addColumnInfo(name = "lowerCri", title = gettext("Lower"), type = "number", overtitle = ciTitle)


### PR DESCRIPTION
Fixes jasp-stats/jaspProphet#13.

Removes gettext() from the argument 'summaryCredibleIntervalWidth' to exclude it from being translated.