### PR TITLE
Release fixes

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -20,6 +20,7 @@ jobs:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       R_REMOTES_UPGRADE: never
       VDIFFR_RUN_TESTS: true
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - uses: actions/checkout@v2

--- a/R/prophet.R
+++ b/R/prophet.R
@@ -489,7 +489,10 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
     prophetTable$addColumnInfo(name = "tailEss", title = gettext("ESS (tail)"), type = "integer")
     
     if (!ready && options$estimation == "mcmc")
-      prophetTable$addFootnote(gettext("Prophet might need a long time to compute the results. You can try it first with fewer MCMC samples to see if it works and if you specified the model correctly (e.g., set 'Samples = 10')."))
+      prophetTable$addFootnote(gettext("Prophet might need a long time to compute the results. You can try it first with fewer MCMC samples to see if it works and if you specified the model correctly (e.g., set 'Samples = 10' in the 'Model' section)."))
+
+    if (options$maxChangepoints > length(prophetModelResults$history$ds))
+    prophetTable$addFootnote(message = gettext("'Max. changepoints' was set higher than the number of cases included in the training data. Prophet uses as many changepoints as training data points instead. This will most likely lead to overfitting of the data. You are advised to reduce 'Max. changepoints'."))
 
     prophetTable$addCitation("Taylor, S. J. & Letham, B. (2018). Forecasting at scale. *The American Statistician, 72*(1), 37-45.")
 
@@ -562,11 +565,14 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
     prophetTable$addColumnInfo(name = "lowerCri", title = gettext("Lower"), type = "number", overtitle = ciTitle)
     prophetTable$addColumnInfo(name = "upperCri", title = gettext("Upper"), type = "number", overtitle = ciTitle)
   }
-  
+
+  if (options$maxChangepoints > length(prophetModelResults$history$ds))
+    prophetTable$addFootnote(message = gettext("'Max. changepoints' was set higher than the number of cases included in the training data. Prophet uses as many changepoints as training data points instead. This will most likely lead to overfitting of the data. You are advised to reduce 'Max. changepoints'."))
+
   prophetTable$addCitation("Taylor, S. J. & Letham, B. (2018). Forecasting at scale. *The American Statistician, 72*(1), 37-45.")
 
   .prophetChangePointTableFill(prophetTable, prophetModelResults, options$estimation, criLevel, ready)
-    
+  
   jaspResults[["prophetMainContainer"]][["prophetChangePointTable"]] <- prophetTable
 
   return()
@@ -700,7 +706,7 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
   xLabels <- attr(xBreaks, "labels")
   yBreaks <- pretty(histDat$y)
   
-  p <- ggplot2::ggplot(data = histDat, mapping = ggplot2::aes(x = x, y = y))
+  p <- ggplot2::ggplot(data = histDat[histDat$x >= xLimits[1] & histDat$x <= xLimits[2], ], mapping = ggplot2::aes(x = x, y = y))
 
   if (options$historyPlotShow == "line" || options$historyPlotShow == "both")
     p <- p + ggplot2::geom_line(color = "black", size = 1.25)

--- a/R/prophet.R
+++ b/R/prophet.R
@@ -491,9 +491,6 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
     if (!ready && options$estimation == "mcmc")
       prophetTable$addFootnote(gettext("Prophet might need a long time to compute the results. You can try it first with fewer MCMC samples to see if it works and if you specified the model correctly (e.g., set 'Samples = 10' in the 'Model' section)."))
 
-    if (options$maxChangepoints > length(prophetModelResults$history$ds))
-    prophetTable$addFootnote(message = gettext("'Max. changepoints' was set higher than the number of cases included in the training data. Prophet uses as many changepoints as training data points instead. This will most likely lead to overfitting of the data. You are advised to reduce 'Max. changepoints'."))
-
     prophetTable$addCitation("Taylor, S. J. & Letham, B. (2018). Forecasting at scale. *The American Statistician, 72*(1), 37-45.")
 
     .prophetModelSummaryTableMcmcFill(prophetTable, prophetModelResults, criLevel, ready)
@@ -565,9 +562,6 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
     prophetTable$addColumnInfo(name = "lowerCri", title = gettext("Lower"), type = "number", overtitle = ciTitle)
     prophetTable$addColumnInfo(name = "upperCri", title = gettext("Upper"), type = "number", overtitle = ciTitle)
   }
-
-  if (options$maxChangepoints > length(prophetModelResults$history$ds))
-    prophetTable$addFootnote(message = gettext("'Max. changepoints' was set higher than the number of cases included in the training data. Prophet uses as many changepoints as training data points instead. This will most likely lead to overfitting of the data. You are advised to reduce 'Max. changepoints'."))
 
   prophetTable$addCitation("Taylor, S. J. & Letham, B. (2018). Forecasting at scale. *The American Statistician, 72*(1), 37-45.")
 

--- a/inst/qml/Prophet.qml
+++ b/inst/qml/Prophet.qml
@@ -91,7 +91,7 @@ Form
 		{
 			value: "logistic"
 			label: qsTr("Logistic")
-			childrenOnSameRow: true
+			childrenOnSameRow: false
 			
 			Group
 			{

--- a/inst/qml/Prophet.qml
+++ b/inst/qml/Prophet.qml
@@ -102,7 +102,7 @@ Form
 					enabled: cap.count === 0
 					visible: growth.value === "logistic"
 					negativeValues: true
-					fieldWidth: 50
+					fieldWidth: 100
 				}
 				DoubleField
 				{
@@ -111,7 +111,7 @@ Form
 					enabled: floor.count === 0
 					visible: growth.value === "logistic"
 					negativeValues: true
-					fieldWidth: 50
+					fieldWidth: 100
 				}
 			}
 		}

--- a/inst/qml/Prophet.qml
+++ b/inst/qml/Prophet.qml
@@ -91,28 +91,25 @@ Form
 		{
 			value: "logistic"
 			label: qsTr("Logistic")
-		}
-	}
-
-	Group
-	{
-		DoubleField
-		{
-			name: "constantCapacity"
-			label: qsTr("Constant carrying capacity")
-			enabled: cap.count === 0
-			visible: growth.value === "logistic"
-			negativeValues: true
-			fieldWidth: 100
-		}
-		DoubleField
-		{
-			name: "constantMinimum"
-			label: qsTr("Constant saturating minimum")
-			enabled: floor.count === 0
-			visible: growth.value === "logistic"
-			negativeValues: true
-			fieldWidth: 100
+			
+			DoubleField
+			{
+				name: "constantCapacity"
+				label: qsTr("Constant carrying capacity")
+				enabled: cap.count === 0
+				visible: growth.value === "logistic"
+				negativeValues: true
+				fieldWidth: 100
+			}
+			DoubleField
+			{
+				name: "constantMinimum"
+				label: qsTr("Constant saturating minimum")
+				enabled: floor.count === 0
+				visible: growth.value === "logistic"
+				negativeValues: true
+				fieldWidth: 100
+			}
 		}
 	}
 

--- a/inst/qml/Prophet.qml
+++ b/inst/qml/Prophet.qml
@@ -91,31 +91,35 @@ Form
 		{
 			value: "logistic"
 			label: qsTr("Logistic")
+			childrenOnSameRow: true
 			
-			DoubleField
+			Group
 			{
-				name: "constantCapacity"
-				label: qsTr("Constant carrying capacity")
-				enabled: cap.count === 0
-				visible: growth.value === "logistic"
-				negativeValues: true
-				fieldWidth: 100
-			}
-			DoubleField
-			{
-				name: "constantMinimum"
-				label: qsTr("Constant saturating minimum")
-				enabled: floor.count === 0
-				visible: growth.value === "logistic"
-				negativeValues: true
-				fieldWidth: 100
+				DoubleField
+				{
+					name: "constantCapacity"
+					label: qsTr("Carrying capacity")
+					enabled: cap.count === 0
+					visible: growth.value === "logistic"
+					negativeValues: true
+					fieldWidth: 50
+				}
+				DoubleField
+				{
+					name: "constantMinimum"
+					label: qsTr("Saturating minimum")
+					enabled: floor.count === 0
+					visible: growth.value === "logistic"
+					negativeValues: true
+					fieldWidth: 50
+				}
 			}
 		}
 	}
 
 	Section
 	{
-		title:      qsTr("Model")
+		title: qsTr("Model")
 		columns: 1
 		Group
 		{
@@ -129,6 +133,7 @@ Form
 					name: "maxChangepoints"
 					label: qsTr("Max. changepoints")
 					defaultValue: 25
+					max: dataSetModel.rowCount()
 				}
 				DoubleField
 				{
@@ -136,6 +141,7 @@ Form
 					label: qsTr("Changepoint range")
 					defaultValue: 0.8
 					decimals: 2
+					min: 0
 					max: 1
 				}
 				DoubleField


### PR DESCRIPTION
Fixes jasp-stats/INTERNAL-jasp#1483, fixes jasp-stats/INTERNAL-jasp#1484, fixes jasp-stats/jasp-test-release#1494, fixes jasp-stats/jasp-test-release#1498

I could not set a maximum to the number of changepoints based on the data in qml directly. Internally, Prophet takes the number of data points as the maximum number of changepoints. Thus, I added a footnote that informs the user about this setting and also warns about overfitting.