### PR TITLE
Fix oversized state

### DIFF
--- a/R/prophet.R
+++ b/R/prophet.R
@@ -34,9 +34,9 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
   .prophetCreateModelSummaryTable(       jaspResults, options, ready)
   .prophetCreateChangePointTable(        jaspResults, options, ready)
   .prophetCreateModelEvaluationTable(    jaspResults, options, ready)
-  return()
   .prophetCreateHistoryPlot(             jaspResults, dataset, options, ready)
   .prophetCreateForecastPlots(           jaspResults, dataset, options, ready)
+  return()
   .prophetCreateSeasonalityPlotContainer(jaspResults, dataset, options, ready)
   .prophetCreateCovariatePlotContainer(  jaspResults, dataset, options, ready)
   .prophetCreatePerformancePlots(        jaspResults, options, ready)
@@ -724,8 +724,8 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
 .prophetCreateForecastPlots <- function(jaspResults, dataset, options, ready) {
   if (!ready) return()
 
-  prophetPredictionResults <- jaspResults[["prophetResults"]][["object"]][["prophetModelResults"]]
   prophetModelResults      <- jaspResults[["prophetResults"]][["object"]][["prophetModelResults"]]
+  prophetPredictionResults <- jaspResults[["prophetResults"]][["object"]][["prophetPredictionResults"]]
 
   prophetForecastPlots <- createJaspContainer(title = gettext("Forecast Plots"))
   prophetForecastPlots$dependOn(.prophetPredictionDependencies())

--- a/R/prophet.R
+++ b/R/prophet.R
@@ -1321,7 +1321,7 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
 # helpers ----
 .prophetIntervalLevels <- function(options, what = c("credible", "prediction")) {
   what <- match.arg(what)
-  criLevel <- (1-options[["credibleIntervalWidth"]])/2
+
   criLevel <- switch(what,
                      credible   = (1-options[["credibleIntervalWidth"]])/2,
                      prediction = (1-options[["predictionIntervalWidth"]])/2)

--- a/R/prophet.R
+++ b/R/prophet.R
@@ -482,7 +482,7 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
 
   if (options$estimation == "map") {
     prophetTable <- createJaspTable(title = "Parameter Estimates Table")
-    prophetTable$dependOn(c("summaryCredibleIntervalWidth"))
+    prophetTable$dependOn(c("credibleIntervalWidth"))
     prophetTable$position <- 1
 
     prophetTable$addColumnInfo(name = "k", title = gettext("Growth rate (k)"), type = "number")
@@ -497,9 +497,9 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
     prophetTable <- createJaspTable(title = gettext("Posterior Summary Table"))
     prophetTable$position <- 2
 
-    criLevel <- (1-options[["summaryCredibleIntervalWidth"]])/2
+    criLevel <- (1-options[["credibleIntervalWidth"]])/2
 
-    overtitle <- gettextf("%s%% CI", options[["summaryCredibleIntervalWidth"]]*100)
+    overtitle <- gettextf("%s%% CI", options[["credibleIntervalWidth"]]*100)
     prophetTable$addColumnInfo(name = "par", title = gettext("Parameter"), type = "string")
     prophetTable$addColumnInfo(name = "mean", title = gettext("Mean"), type = "number")
     prophetTable$addColumnInfo(name = "sd", title = gettext("SD"), type = "number")
@@ -566,10 +566,10 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
                   map  = gettext("Changepoint Estimates Table"),
                   mcmc = gettext("Changepoint Posterior Summary Table"))
   prophetTable <- createJaspTable(title = title)
-  prophetTable$dependOn(c("changePointTable", "summaryCredibleIntervalWidth"))
+  prophetTable$dependOn(c("changePointTable", "credibleIntervalWidth"))
   prophetTable$position <- 3
 
-  criLevel <- (1-options[["summaryCredibleIntervalWidth"]])/2
+  criLevel <- (1-options[["credibleIntervalWidth"]])/2
 
   prophetTable$addColumnInfo(name = "ds", title = gettext("Changepoint"), type = "string")
 
@@ -577,7 +577,7 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
     prophetTable$addColumnInfo(name = "delta", title = gettext("Change in growth rate (\u03B4)"), type = "number")
   } else {
     parTitle <- gettext("Change in growth rate (\u03B4)")
-    ciTitle  <- gettextf("%s%% CI", options[["summaryCredibleIntervalWidth"]]*100)
+    ciTitle  <- gettextf("%s%% CI", options[["credibleIntervalWidth"]]*100)
     prophetTable$addColumnInfo(name = "mean", title = gettext("Mean"), type = "number", overtitle = parTitle)
     prophetTable$addColumnInfo(name = "sd", title = gettext("SD"), type = "number", overtitle = parTitle)
     prophetTable$addColumnInfo(name = "lowerCri", title = gettext("Lower"), type = "number", overtitle = ciTitle)
@@ -1321,9 +1321,9 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
 # helpers ----
 .prophetIntervalLevels <- function(options, what = c("credible", "prediction")) {
   what <- match.arg(what)
-  criLevel <- (1-options[["summaryCredibleIntervalWidth"]])/2
+  criLevel <- (1-options[["credibleIntervalWidth"]])/2
   criLevel <- switch(what,
-                     credible   = (1-options[["summaryCredibleIntervalWidth"]])/2,
+                     credible   = (1-options[["credibleIntervalWidth"]])/2,
                      prediction = (1-options[["predictionIntervalWidth"]])/2)
 
   return(c(criLevel, 1-criLevel))

--- a/R/prophet.R
+++ b/R/prophet.R
@@ -19,7 +19,7 @@
 Prophet <- function(jaspResults, dataset = NULL, options) {
 
   options <- .prophetInitOptions(jaspResults, options)
-  
+
   if (options$growth == "logistic")
     ready <- (options$dependent != "" && options$time != "") && (options$capacity != "" || options$constantCapacity != options$constantMinimum)
   else
@@ -27,20 +27,21 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
 
   dataset <- .prophetReadData(options, ready)
   errors  <- .prophetErrorHandling(dataset, options, ready)
-  
+
   .prophetComputeResults(jaspResults, dataset, options, ready)
 
   .prophetContainerMain(                 jaspResults, options, ready)
   .prophetCreateModelSummaryTable(       jaspResults, options, ready)
   .prophetCreateChangePointTable(        jaspResults, options, ready)
   .prophetCreateModelEvaluationTable(    jaspResults, options, ready)
+  return()
   .prophetCreateHistoryPlot(             jaspResults, dataset, options, ready)
   .prophetCreateForecastPlots(           jaspResults, dataset, options, ready)
   .prophetCreateSeasonalityPlotContainer(jaspResults, dataset, options, ready)
   .prophetCreateCovariatePlotContainer(  jaspResults, dataset, options, ready)
   .prophetCreatePerformancePlots(        jaspResults, options, ready)
   .prophetCreateParameterPlots(          jaspResults, options, ready)
-  
+
   return()
 }
 
@@ -70,11 +71,11 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
 
 .prophetErrorHandling <- function(dataset, options, ready) {
   if(!ready) return()
-  
+
   checks <- list(
     .dateTimeArgChecks <- function() {
       timeVar <- try(as.POSIXct(dataset[[encodeColNames(options$time)]], tz = "UTC"))
-      
+
       if (isTryError(timeVar))
         return(gettext("'Time' must be in a date-like format (e.g., yyyy-mm-dd hh:mm:ss)"))
 
@@ -83,17 +84,17 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
         && options$nonperiodicalPredictionEnd != "") {
         predStart <- try(as.POSIXct(options$nonperiodicalPredictionStart))
         predEnd <- try(as.POSIXct(options$nonperiodicalPredictionEnd))
-        
+
         if (isTryError(predStart))
           return(gettext("'Start' for nonperiodical prediction must be in a date-like format (e.g., yyyy-mm-dd hh:mm:ss)"))
-        
+
         if (isTryError(predEnd))
           return(gettext("'End' for nonperiodical prediction must be in a date-like format (e.g., yyyy-mm-dd hh:mm:ss)"))
       }
 
       return()
     },
-    
+
     .logicalVarChecks <- function() {
       isChangepoint <- dataset[[encodeColNames(options$changepoints)]]
 
@@ -104,7 +105,7 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
 
       if (any(is.na(as.logical(isHistory))) || !all(unique(as.numeric(isHistory)) %in% c(0, 1)))
         return(gettext("'History Indicator' must be a logical variable (e.g., 0/1)"))
-      
+
       return()
     },
 
@@ -149,14 +150,14 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
     .predictionChecks <- function() {
       if (options$capacity == "" && options$minimum == "" && length(options$covariates) == 0)
         return()
-      
+
       ds    <- as.POSIXct(dataset[[encodeColNames(options$time)]], tz = "UTC")
 
       if (options$historyIndicator != "")
         idx <- as.logical(dataset[[encodeColNames(options$historyIndicator)]])
       else
         idx <- !logical(length(ds))
-      
+
       futds <- as.POSIXct(switch(options$predictionType,
                                  periodicalPrediction = seq(max(ds[idx]),
                                                            length.out = options$periodicalPredictionNumber + 1,
@@ -165,17 +166,17 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
                                                                as.POSIXct(options$nonperiodicalPredictionEnd),
                                                                by = options$nonPeriodicalPredictionUnit)),
                           tz = "UTC")
-      
+
       if (!all(futds %in% ds) && options$capacity != "")
         return(gettext("'Carrying Capacity' must be supplied for predictions"))
 
       if (!all(futds %in% ds) && length(options$covariates) > 0)
         return(gettext("'Covariates' must be supplied for predictions"))
-      
+
       return()
     }
   )
-  
+
   targetVars <- c(options$dependent, unlist(options$covariates))
   if (options$capacity != "")
     targetVars <- c(targetVars, options$capacity)
@@ -194,77 +195,60 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
 
 .prophetModelDependencies <- function(options) {
   if (options$changepoints != "") {
-    return(c("dependent", "time", "changepoints", "capacity", "minimum", "covariates", 
+    return(c("dependent", "time", "changepoints", "capacity", "minimum", "covariates",
              "historyIndicator", "growth", "constantCapacity", "constantMinimum",
              "assignedCovariates", "seasonalities",
-             "estimation", "mcmcSamples", "predictionIntervalWidth", 
+             "estimation", "mcmcSamples", "predictionIntervalWidth",
              "predictionIntervalSamples"))
   } else {
-    return(c("dependent", "time", "changepoints", "capacity", "minimum", "covariates", 
+    return(c("dependent", "time", "changepoints", "capacity", "minimum", "covariates",
              "historyIndicator", "growth", "constantCapacity", "constantMinimum",
              "maxChangepoints", "changepointRange", "changepointPriorScale",
              "assignedCovariates", "seasonalities",
-             "estimation", "mcmcSamples", "predictionIntervalWidth", 
+             "estimation", "mcmcSamples", "predictionIntervalWidth",
              "predictionIntervalSamples"))
   }
 }
 
 .prophetPredictionDependencies <- function() {
-  return(c("predictionType", 
-           "periodicalPredictionNumber", 
+  return(c("predictionType",
+           "periodicalPredictionNumber",
            "periodicalPredictionUnit",
-           "nonperiodicalPredictionStart", 
+           "nonperiodicalPredictionStart",
            "nonperiodicalPredictionEnd",
            "nonperiodicalPredictionUnit"))
 }
 
 .prophetEvaluationDependencies <- function() {
-  return(c("crossValidation", "crossValidationUnit", "crossValidationHorizon", 
+  return(c("crossValidation", "crossValidationUnit", "crossValidationHorizon",
            "crossValidationPeriod", "crossValidationInitial"))
 }
 
 # Results functions ----
 .prophetComputeResults <- function(jaspResults, dataset, options, ready) {
   if (!ready) return()
-  
+
   if (is.null(jaspResults[["prophetResults"]])) {
-    prophetResults <- createJaspContainer("prophetResults")
-    
-    jaspResults[["prophetResults"]] <- prophetResults
-    jaspResults[["prophetResults"]]$dependOn(.prophetModelDependencies(options))
+    prophetModelFullResults  <- .prophetModelResultsHelper(dataset, options)
+    prophetPredictionResults <- .prophetPredictionResultsHelper(dataset, options, prophetModelFullResults)
+    prophetEvaluationResults <- .prophetEvaluationResultsHelper(dataset, options, prophetModelFullResults)
+
+    prophetResults <- list()
+    prophetResults[["prophetModelResults"]] <- .prophetModelResultsReduce(prophetModelFullResults, options)
+    prophetResults[["prophetPredictionResults"]] <- prophetPredictionResults
+    prophetResults[["prophetEvaluationResults"]] <- prophetEvaluationResults
+
+    jaspResults[["prophetResults"]] <-
+      createJaspState(object       = prophetResults,
+                      dependencies = unique(c(.prophetModelDependencies(options),
+                                       .prophetPredictionDependencies(),
+                                       .prophetEvaluationDependencies()
+                                       ))
+                      )
   }
-  
-  if (is.null(jaspResults[["prophetResults"]][["prophetModelResults"]])) {
-    prophetModelResultsState <- createJaspState()
-    prophetModelResults <- .prophetModelResultsHelper(dataset, options)
-    prophetModelResultsState$object <- prophetModelResults
-    jaspResults[["prophetResults"]][["prophetModelResults"]] <- prophetModelResultsState
-  }
-  
-  if (is.null(jaspResults[["prophetResults"]][["prophetPredictionResults"]])
-    && ((options$predictionType == "nonperiodicalPrediction"
-         && options$nonperiodicalPredictionStart != ""
-         && options$nonperiodicalPredictionEnd != "")
-        || options$predictionType == "periodicalPrediction")) {
-    prophetPredictionResultsState <- createJaspState()
-    prophetPredictionResultsState$dependOn(.prophetPredictionDependencies())
-    prophetModelResults <- jaspResults[["prophetResults"]][["prophetModelResults"]]$object
-    prophetPredictionResults <- .prophetPredictionResultsHelper(dataset, options, prophetModelResults)
-    prophetPredictionResultsState$object <- prophetPredictionResults
-    jaspResults[["prophetResults"]][["prophetPredictionResults"]] <- prophetPredictionResultsState
-  }
-  
+
   .prophetSavePredictions(jaspResults, options)
 
-  if (is.null(jaspResults[["prophetResults"]][["prophetEvaluationResults"]]) && options$crossValidation) {
-    prophetEvaluationResultsState <- createJaspState()
-    prophetEvaluationResultsState$dependOn(.prophetEvaluationDependencies())
-    prophetModelResults <- jaspResults[["prophetResults"]][["prophetModelResults"]]$object
-    prophetEvaluationResults <- .prophetEvaluationResultsHelper(dataset, options, prophetModelResults)
-    prophetEvaluationResultsState$object <- prophetEvaluationResults
-    jaspResults[["prophetResults"]][["prophetEvaluationResults"]] <- prophetEvaluationResultsState
-  }
-  
   return()
 }
 
@@ -278,7 +262,7 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
     idx <- !logical(length(ds))
 
   fitDat <- data.frame(y = y, ds = ds)
-  
+
   if (options$changepoints != "") {
     isChangepoint <- as.logical(dataset[[encodeColNames(options$changepoints)]])
     cp            <- ds[isChangepoint & idx]
@@ -291,7 +275,7 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
       fitDat$cap <- as.numeric(dataset[[encodeColNames(options$capacity)]])
     else
       fitDat$cap <- options$constantCapacity
-    
+
     if (options$minimum != "")
       fitDat$floor <- as.numeric(dataset[[encodeColNames(options$minimum)]])
     else
@@ -318,9 +302,9 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
                           interval.width = options$predictionIntervalWidth,
                           uncertainty.samples = predIntSamples,
                           fit = FALSE)
-  
+
   if (length(options$assignedCovariates) > 0) {
-    
+
     for (cov in options$assignedCovariates) {
       mod     <- prophet::add_regressor(m = mod,
                                         name = cov$variable,
@@ -332,7 +316,7 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
       fitDat[[cov$variable]] <- datCov
     }
   }
-  
+
   if (!is.null(options$seasonalities)) {
     i <- 1
 
@@ -355,28 +339,45 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
       i   <- i+1
     }
   }
-  
+
   fitDat  <- fitDat[idx, ]
 
   fit     <- prophet::fit.prophet(m = mod, df = fitDat)
-  
+
   return(fit)
 }
 
-.prophetPredictionResultsHelper <- function(dataset, options, prophetModelResults) { 
+.prophetModelResultsReduce <- function(prophetModelResults, options) {
+  if (options$estimation == "mcmc") {
+    ci <- .prophetIntervalLevels(options, "credible")
+    ciNames <- paste0(100*ci, "%")
+    modelSummary <- rstan::monitor(prophetModelResults$stan.fit, probs = .prophetIntervalLevels(options, "credible"))
+    modelSummary <- as.data.frame(modelSummary)
+    modelSummary <- modelSummary[, c("mean", "sd", ciNames, "n_eff", "Rhat", "Bulk_ESS", "Tail_ESS")]
+    colnames(modelSummary) <- c("mean", "sd", "lower", "upper", "n_eff", "Rhat", "Bulk_ESS", "Tail_ESS")
+    prophetModelResults$modelSummary <- modelSummary
+
+
+    prophetModelResults$stan.fit <- NULL
+    prophetModelResults$params   <- NULL
+  }
+  return(prophetModelResults)
+}
+
+.prophetPredictionResultsHelper <- function(dataset, options, prophetModelResults) {
   futDat <- NULL
-  
+
   if (options$predictionType == "periodicalPrediction") {
-    futDat <- prophet::make_future_dataframe(m = prophetModelResults, 
-                                             periods = options$periodicalPredictionNumber, 
-                                             freq = options$periodicalPredictionUnit, 
+    futDat <- prophet::make_future_dataframe(m = prophetModelResults,
+                                             periods = options$periodicalPredictionNumber,
+                                             freq = options$periodicalPredictionUnit,
                                              include_history = TRUE)
   } else {
-    futDat <- data.frame(ds = seq(as.POSIXct(options$nonperiodicalPredictionStart), 
-                                  as.POSIXct(options$nonperiodicalPredictionEnd), 
+    futDat <- data.frame(ds = seq(as.POSIXct(options$nonperiodicalPredictionStart),
+                                  as.POSIXct(options$nonperiodicalPredictionEnd),
                                   by = options$nonperiodicalPredictionUnit))
   }
-  
+
   futds <- as.POSIXct(futDat$ds, tz = "UTC")
   ds    <- as.POSIXct(dataset[[encodeColNames(options$time)]], tz = "UTC")
 
@@ -398,7 +399,7 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
 
   if (length(options$covariates) > 0) {
     covs <- unlist(options$covariates)
-    
+
     for (cov in covs) {
       futCov        <- dataset[[encodeColNames(cov)]]
       futDat[[cov]] <- futCov[ds %in% futds]
@@ -406,7 +407,7 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
   }
 
   pred <- predict(prophetModelResults, futDat)
-  
+
   cps <- prophetModelResults$changepoints
   pred$isChangepoint <- pred$ds %in% cps
 
@@ -414,9 +415,9 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
 }
 
 .prophetEvaluationResultsHelper <- function(dataset, options, prophetModelResults) {
-  
-  cvDat <- prophet::cross_validation(model   = prophetModelResults, 
-                                     horizon = options$crossValidationHorizon, 
+
+  cvDat <- prophet::cross_validation(model   = prophetModelResults,
+                                     horizon = options$crossValidationHorizon,
                                      units   = options$crossValidationUnit,
                                      period  = options$crossValidationPeriod,
                                      initial = options$crossValidationInitial)
@@ -426,17 +427,17 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
 
 # Saving functions ----
 .prophetSavePredictions <- function(jaspResults, options) {
-  if (is.null(jaspResults[["prophetResults"]][["prophetPredictionSavePath"]])) {
+  if (is.null(jaspResults[["prophetPredictionSavePath"]])) {
     predSavePath <- createJaspState()
     predSavePath$dependOn(c(.prophetPredictionDependencies(), "predictionSavePath"))
-    jaspResults[["prophetResults"]][["prophetPredictionSavePath"]] <- predSavePath
+    jaspResults[["prophetPredictionSavePath"]] <- predSavePath
   }
 
   if (options$predictionSavePath != "") {
-    write.csv(jaspResults[["prophetResults"]][["prophetPredictionResults"]]$object,
+    write.csv(jaspResults[["prophetResults"]][["object"]][["prophetModelResults"]],
               file = options$predictionSavePath,
               row.names = FALSE)
-    predSavePath$object <- TRUE
+    predSavePath[["object"]] <- TRUE
   }
 
   return()
@@ -445,33 +446,33 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
 # Output functions ----
 .prophetContainerMain <- function(jaspResults, options, ready) {
   if (!is.null(jaspResults[["prophetMainContainer"]])) return()
-  
+
   mainContainer <- createJaspContainer()
-  
+
   jaspResults[["prophetMainContainer"]] <- mainContainer
   jaspResults[["prophetMainContainer"]]$dependOn(.prophetModelDependencies(options))
-  
+
   return()
 }
 
 .prophetCreateModelSummaryTable <- function(jaspResults, options, ready) {
   if (!is.null(jaspResults[["prophetMainContainer"]][["prophetModelSummaryTable"]])) return()
-  
-  prophetModelResults <- jaspResults[["prophetResults"]][["prophetModelResults"]]$object
-  
+
+  prophetModelResults <- jaspResults[["prophetResults"]][["object"]][["prophetModelResults"]]
+
   if (options$estimation == "map") {
     prophetTable <- createJaspTable(title = "Parameter Estimates Table")
     prophetTable$dependOn(c("summaryCredibleIntervalWidth"))
     prophetTable$position <- 1
-    
+
     prophetTable$addColumnInfo(name = "k", title = gettext("Growth rate (k)"), type = "number")
     prophetTable$addColumnInfo(name = "m", title = gettext("Offset (m)"), type = "number")
     prophetTable$addColumnInfo(name = "sigmaObs", title = gettext("Residual variance (\u03C3\u00B2)"), type = "number")
-    
+
     .prophetModelSummaryTableMapFill(prophetTable, prophetModelResults, ready)
-    
+
     jaspResults[["prophetMainContainer"]][["prophetTable"]] <- prophetTable
-    
+
   } else {
     prophetTable <- createJaspTable(title = gettext("Posterior Summary Table"))
     prophetTable$position <- 2
@@ -487,25 +488,25 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
     prophetTable$addColumnInfo(name = "rhat", title = gettext("R-hat"), type = "number")
     prophetTable$addColumnInfo(name = "bulkEss", title = gettext("ESS (bulk)"), type = "integer")
     prophetTable$addColumnInfo(name = "tailEss", title = gettext("ESS (tail)"), type = "integer")
-    
+
     if (!ready && options$estimation == "mcmc")
       prophetTable$addFootnote(gettext("Prophet might need a long time to compute the results. You can try it first with fewer MCMC samples to see if it works and if you specified the model correctly (e.g., set 'Samples = 10' in the 'Model' section)."))
 
     prophetTable$addCitation("Taylor, S. J. & Letham, B. (2018). Forecasting at scale. *The American Statistician, 72*(1), 37-45.")
 
     .prophetModelSummaryTableMcmcFill(prophetTable, prophetModelResults, criLevel, ready)
-    
+
     jaspResults[["prophetMainContainer"]][["prophetTable"]] <- prophetTable
   }
-  
+
   return()
 }
 
 .prophetModelSummaryTableMapFill <- function(prophetTable, prophetModelResults, ready) {
   if (!ready) return()
-  
+
   pars <- prophetModelResults$params
-  
+
   prophetTable$addRows(list(
     k        = pars$k,
     m        = pars$m,
@@ -515,19 +516,19 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
 
 .prophetModelSummaryTableMcmcFill <- function(prophetTable, prophetModelResults, criLevel, ready) {
   if (!ready) return()
-  
-  modelSummary         <- rstan::monitor(prophetModelResults$stan.fit, probs = c(criLevel, 1-criLevel))
+
+  modelSummary         <- prophetModelResults$modelSummary
   modelSummaryRowNames <- rownames(modelSummary)
   parNames             <- c("k", "m", "sigma_obs")
-  parSummary           <- modelSummary[modelSummaryRowNames %in% parNames, 1:ncol(modelSummary)]
+  parSummary           <- modelSummary[modelSummaryRowNames %in% parNames,]
   parLabels            <- c(gettext("Growth rate (k)"), gettext("Offset (m)"), gettext("Residual variance (sigma)"))
-  
+
   prophetTable$addColumns(list(
     par      = parLabels,
     mean     = parSummary[["mean"]],
     sd       = parSummary[["sd"]],
-    lowerCri = parSummary[[paste0(criLevel*100, "%")]],
-    upperCri = parSummary[[paste0(100-criLevel*100, "%")]],
+    lowerCri = parSummary[["lower"]],
+    upperCri = parSummary[["upper"]],
     rhat     = parSummary[["Rhat"]],
     bulkEss  = parSummary[["Bulk_ESS"]],
     tailEss  = parSummary[["Tail_ESS"]]
@@ -539,8 +540,8 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
 .prophetCreateChangePointTable <- function(jaspResults, options, ready) {
   if (!is.null(jaspResults[["prophetMainContainer"]][["prophetChangePointTable"]]) || !options$changePointTable) return()
 
-  prophetModelResults <- jaspResults[["prophetResults"]][["prophetModelResults"]]$object
-  
+  prophetModelResults <- jaspResults[["prophetResults"]][["object"]][["prophetModelResults"]]
+
   title <- switch(options$estimation,
                   map  = gettext("Changepoint Estimates Table"),
                   mcmc = gettext("Changepoint Posterior Summary Table"))
@@ -551,7 +552,7 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
   criLevel <- (1-options[["summaryCredibleIntervalWidth"]])/2
 
   prophetTable$addColumnInfo(name = "ds", title = gettext("Changepoint"), type = "string")
-  
+
   if (options$estimation == "map") {
     prophetTable$addColumnInfo(name = "delta", title = gettext("Change in growth rate (\u03B4)"), type = "number")
   } else {
@@ -566,7 +567,7 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
   prophetTable$addCitation("Taylor, S. J. & Letham, B. (2018). Forecasting at scale. *The American Statistician, 72*(1), 37-45.")
 
   .prophetChangePointTableFill(prophetTable, prophetModelResults, options$estimation, criLevel, ready)
-  
+
   jaspResults[["prophetMainContainer"]][["prophetChangePointTable"]] <- prophetTable
 
   return()
@@ -575,25 +576,22 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
 .prophetChangePointTableFill <-  function(prophetTable, prophetModelResults, estimation, criLevel, ready) {
   if (!ready) return()
 
-  delta  <- switch(estimation,
-                   map  = as.numeric(prophetModelResults[["params"]][["delta"]]),
-                   mcmc = as.numeric(apply(prophetModelResults[["params"]][["delta"]], 2, mean)))
   cps    <- as.character(prophetModelResults$changepoints)
 
   if (estimation == "map") {
     prophetTable$addColumns(list(
       ds    = cps,
-      delta = delta
+      delta = as.numeric(prophetModelResults[["params"]][["delta"]])
     ))
   } else {
-    deltaCri <- apply(prophetModelResults[["params"]][["delta"]], 2, quantile, probs = c(criLevel, 1-criLevel))
-    deltaSd  <- apply(prophetModelResults[["params"]][["delta"]], 2, sd)
+    delta <- prophetModelResults[["modelSummary"]]
+    delta <- delta[startsWith(rownames(delta), "delta"),]
     prophetTable$addColumns(list(
       ds       = cps,
-      mean     = delta,
-      sd       = deltaSd,
-      lowerCri = deltaCri[1,],
-      upperCri = deltaCri[2,]
+      mean     = delta[["mean"]],
+      sd       = delta[["sd"]],
+      lowerCri = delta[["lower"]],
+      upperCri = delta[["upper"]]
     ))
   }
 
@@ -602,25 +600,25 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
 
 .prophetCreateModelEvaluationTable <- function(jaspResults, options, ready) {
   if (!is.null(jaspResults[["prophetMainContainer"]][["prophetModelEvaluationTable"]]) || !(options$performanceMetrics && options$crossValidation)) return()
-  
-  prophetEvaluationResults <- jaspResults[["prophetResults"]][["prophetEvaluationResults"]]$object
-  
+
+  prophetEvaluationResults <- jaspResults[["prophetResults"]][["object"]][["prophetEvaluationResults"]]
+
   prophetTable <- createJaspTable(gettext("Simulated Historical Forecasts Table"))
-  prophetTable$dependOn(c(.prophetEvaluationDependencies(), "performanceMetrics", 
+  prophetTable$dependOn(c(.prophetEvaluationDependencies(), "performanceMetrics",
                          "performanceMetricsMse", "performanceMetricsRmse", "performanceMetricsMape"))
   prophetTable$position <- 4
-  
+
   prophetTable$addColumnInfo(name = "horizon", title = gettext("Horizon"), type = "string")
-  
+
   if (options$performanceMetricsMse)  prophetTable$addColumnInfo(name = "mse", title = gettext("MSE"), type = "number")
   if (options$performanceMetricsRmse) prophetTable$addColumnInfo(name = "rmse", title = gettext("RMSE"), type = "number")
   if (options$performanceMetricsMape) prophetTable$addColumnInfo(name = "mape", title = gettext("MAPE"), type = "number", format = "pc")
-  
+
   if (isTryError(prophetEvaluationResults))
     prophetTable$addFootnote(message = gettext(.extractErrorMessage(prophetEvaluationResults)))
   else
     .prophetModelEvaluationTableFill(prophetTable, options, prophetEvaluationResults, ready)
-  
+
   prophetTable$addCitation("Taylor, S. J. & Letham, B. (2018). Forecasting at scale. *The American Statistician, 72*(1), 37-45.")
 
   jaspResults[["prophetMainContainer"]][["prophetModelEvaluationTable"]] <- prophetTable
@@ -633,12 +631,12 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
 
   metrics <- c("mse", "rmse", "mape")
   metrics <- metrics[c(options$performanceMetricsMse, options$performanceMetricsRmse, options$performanceMetricsMape)]
-  
+
   metDat <- prophet::performance_metrics(df = prophetEvaluationResults, metrics = metrics, rolling_window = 0)
 
   if (options$crossValidationUnit == "weeks")
     metDat$horizon <- metDat$horizon / 7
-  
+
   prophetTable$addColumns(as.list(metDat))
 
   return()
@@ -646,20 +644,20 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
 
 .prophetCreateHistoryPlot <- function(jaspResults, dataset, options, ready) {
   if (!ready || !options$historyPlot) return()
-  
+
   prophetHistoryPlot <- createJaspPlot(title = "History Plot", height = 320, width = 480)
   prophetHistoryPlot$dependOn(c("dependent", "time", "historyIndicator", "historyPlot", "historyPlotShow", "historyPlotRange", "historyPlotStart",
                                "historyPlotEnd"))
   prophetHistoryPlot$position <- 1
-  
+
   p <- try(.prophetHistoryPlotFill(dataset, options))
   if (isTryError(p))
     prophetHistoryPlot$setError(gettext(.extractErrorMessage(p)))
   else
     prophetHistoryPlot$plotObject <- p
-  
+
   jaspResults[["historyPlot"]] <- prophetHistoryPlot
-  
+
   return()
 }
 
@@ -677,7 +675,7 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
   histDat <- na.omit(data.frame(y = y, x = ds)[idx, ])
 
   xLimits <- range(histDat$x)
-  
+
   if (options$historyPlotRange) {
     if (options$historyPlotStart != "") {
       xLimLower <- try(as.POSIXct(options$historyPlotStart))
@@ -699,7 +697,7 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
   xBreaks <- pretty(xLimits)
   xLabels <- attr(xBreaks, "labels")
   yBreaks <- pretty(histDat$y)
-  
+
   p <- ggplot2::ggplot(data = histDat[histDat$x >= xLimits[1] & histDat$x <= xLimits[2], ], mapping = ggplot2::aes(x = x, y = y))
 
   if (options$historyPlotShow == "line" || options$historyPlotShow == "both")
@@ -708,11 +706,11 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
   if (options$historyPlotShow == "points" || options$historyPlotShow == "both")
     p <- p + ggplot2::geom_point(size = 3, color = "grey")
 
-  p <- p + ggplot2::scale_x_datetime(name = options$time, 
-                                     breaks = xBreaks, 
+  p <- p + ggplot2::scale_x_datetime(name = options$time,
+                                     breaks = xBreaks,
                                      labels = xLabels,
-                                     limits = range(xBreaks)) + 
-    
+                                     limits = range(xBreaks)) +
+
     ggplot2::scale_y_continuous(name = options$dependent,
                                 limits = range(yBreaks),
                                 breaks = yBreaks)
@@ -725,68 +723,68 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
 
 .prophetCreateForecastPlots <- function(jaspResults, dataset, options, ready) {
   if (!ready) return()
-  
-  prophetPredictionResults <- jaspResults[["prophetResults"]][["prophetPredictionResults"]]$object
-  prophetModelResults      <- jaspResults[["prophetResults"]][["prophetModelResults"]]$object
-  
+
+  prophetPredictionResults <- jaspResults[["prophetResults"]][["object"]][["prophetModelResults"]]
+  prophetModelResults      <- jaspResults[["prophetResults"]][["object"]][["prophetModelResults"]]
+
   prophetForecastPlots <- createJaspContainer(title = gettext("Forecast Plots"))
   prophetForecastPlots$dependOn(.prophetPredictionDependencies())
   prophetForecastPlots$position <- 5
-  
+
   if (options$forecastPlotsOverall) .prophetCreateOverallForecastPlot(prophetForecastPlots, dataset, options, prophetPredictionResults)
   if (options$forecastPlotsTrend)   .prophetCreateTrendForecastPlot(prophetForecastPlots, dataset, options, prophetPredictionResults)
-  
+
   jaspResults[["prophetMainContainer"]][["prophetForecastPlots"]] <- prophetForecastPlots
-  
+
   return()
 }
 
 .prophetCreateOverallForecastPlot <- function(prophetForecastPlots, dataset, options, prophetPredictionResults) {
   if (!is.null(prophetForecastPlots[["prophetOverallForecastPlot"]])) return()
-  
+
   prophetOverallForecastPlot <- createJaspPlot(title = gettext("Overall"), height = 320, width = 480)
   prophetOverallForecastPlot$dependOn(c("forecastPlotsOverall", "forecastPlotsOverallAddData",
                                         "forecastPlotsOverallAddCapacity", "forecastPlotsOverallAddMinimum",
                                        "forecastPlotsOverallAddChangepoints", "forecastPlotsOverallRange",
                                        "forecastPlotsOverallStart", "forecastPlotsOverallEnd"))
-  
+
   p <- try(.prophetForecastPlotFill(prophetPredictionResults, dataset, options, type = "yhat"))
 
   if (isTryError(p))
     prophetOverallForecastPlot$setError(gettext(.extractErrorMessage(p)))
   else
     prophetOverallForecastPlot$plotObject <- p
-  
+
   prophetForecastPlots[["prophetOverallForecastPlot"]] <- prophetOverallForecastPlot
-  
+
   return()
 }
 
 .prophetCreateTrendForecastPlot <- function(prophetForecastPlots, dataset, options, prophetPredictionResults) {
   if (!is.null(prophetForecastPlots[["prophetTrendForecastPlot"]])) return()
-  
+
   prophetTrendForecastPlot <- createJaspPlot(title = gettext("Trend"), height = 320, width = 480)
   prophetTrendForecastPlot$dependOn(c("forecastPlotsTrend", "forecastPlotsTrendAddChangepoints",
                                        "forecastPlotsTrendRange",
                                        "forecastPlotsTrendStart", "forecastPlotsTrendEnd"))
-  
+
   p <- try(.prophetForecastPlotFill(prophetPredictionResults, dataset, options, type = "trend"))
 
   if (isTryError(p))
     prophetTrendForecastPlot$setError(gettext(.extractErrorMessage(p)))
   else
     prophetTrendForecastPlot$plotObject <- p
-  
+
   prophetForecastPlots[["prophetTrendForecastPlot"]] <- prophetTrendForecastPlot
-  
+
   return()
 }
 
 .prophetCreateSeasonalityPlotContainer <- function(jaspResults, dataset, options, ready) {
   if (!ready) return()
-  
-  prophetModelResults <- jaspResults[["prophetResults"]][["prophetModelResults"]]$object
-  
+
+  prophetModelResults <- jaspResults[["prophetResults"]][["object"]][["prophetModelResults"]]
+
   prophetSeasonalityPlots <- createJaspContainer(title = gettext("Seasonality Plots"))
   prophetSeasonalityPlots$dependOn(c("seasonalityPlots"))
   prophetSeasonalityPlots$position <- 6
@@ -796,9 +794,9 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
       .prophetCreateSeasonalityPlot(prophetSeasonalityPlots, name, prophetModelResults, options)
     }
   }
-  
+
   jaspResults[["prophetMainContainer"]][["prophetSeasonalityPlots"]] <- prophetSeasonalityPlots
-  
+
   return()
 }
 
@@ -831,7 +829,7 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
       futDat[[cov]] <- 0
     }
   }
-  
+
   predSeas <- predict(prophetModelResults, futDat)
 
   return(predSeas)
@@ -878,9 +876,9 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
   xFormat <- .prophetGetPrettyDateLabels(period, unit)
 
   p <- ggplot2::ggplot(df, mapping = ggplot2::aes(x = x, y = y)) +
-    
+
     ggplot2::geom_line(color = "black", size = 1.25) +
-  
+
     ggplot2::geom_ribbon(mapping = ggplot2::aes(ymin = ymin, ymax = ymax), fill = "blue", alpha = 0.4) +
 
     ggplot2::scale_x_datetime(name = xFormat$label,
@@ -907,7 +905,7 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
 }
 
 .prophetForecastPlotFill <- function(prophetPredictionResults, dataset, options, type) {
-  
+
   yHist <- dataset[[encodeColNames(options$dependent)]]
   xHist <- as.POSIXct(dataset[[encodeColNames(options$time)]], tz = "UTC")
 
@@ -917,7 +915,7 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
     idx <- !logical(length(xHist))
 
   histDat <- na.omit(data.frame(y = yHist, x = xHist)[idx, ])
-  
+
   x <- try(as.POSIXct(prophetPredictionResults[["ds"]], tz = "UTC"))
 
   if (isTryError(x) && options$predictionType == "nonperiodicalPrediction")
@@ -927,22 +925,22 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
   ymin  <- prophetPredictionResults[[paste0(type, "_lower")]]
   ymax  <- prophetPredictionResults[[paste0(type, "_upper")]]
   df    <- data.frame(x = x, y = y, ymin = ymin, ymax = ymax)
-  
+
   if (options$growth == "logistic") {
     df$cap   <- prophetPredictionResults[["cap"]]
     df$floor <- prophetPredictionResults[["floor"]]
   }
-  
+
   p <- ggplot2::ggplot()
-  
+
   if (options$forecastPlotsOverallAddData && type == "yhat")
     p <- p + ggplot2::geom_point(data = histDat, mapping = ggplot2::aes(x = x, y = y), size = 3, color = "grey")
 
-  p <- p + 
+  p <- p +
     ggplot2::geom_line(data = df, mapping = ggplot2::aes(x = x, y = y), color = "black", size = 1.25) +
-  
+
     ggplot2::geom_ribbon(data = df, mapping = ggplot2::aes(x = x, y = y, ymin = ymin, ymax = ymax), fill = "blue", alpha = 0.4)
-  
+
   if (options$growth == "logistic" && type == "yhat") {
     if (options$forecastPlotsOverallAddCapacity)
       p <- p + ggplot2::geom_line(data = df, mapping = ggplot2::aes(x = x, y = cap), color = "black", size = 0.75)
@@ -993,21 +991,21 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
   xLabels <- attr(xBreaks, "labels")
   yBreaks <- pretty(unlist(list(df[, -which(names(df) == "x")]), histDat[, -which(names(df) == "x")]))
 
-  if ((options$forecastPlotsOverallAddChangepoints && type == "yhat") 
+  if ((options$forecastPlotsOverallAddChangepoints && type == "yhat")
     || (options$forecastPlotsTrendAddChangepoints && type == "trend")) {
     isChangepoint <- as.logical(prophetPredictionResults[["isChangepoint"]], tz = "UTC")
     cpDat <- data.frame(x = df$x[isChangepoint], xend = df$x[isChangepoint], y = min(yBreaks), yend = max(yBreaks))
     p <- p + ggplot2::geom_segment(data = cpDat, mapping = ggplot2::aes(x = x, xend = xend, y = y, yend = yend))
   }
 
-  p <- p + ggplot2::geom_segment(mapping = ggplot2::aes(x = histDat$x[length(histDat$x)], y = min(yBreaks), 
-                                                        xend = histDat$x[length(histDat$x)]), yend = max(yBreaks), 
+  p <- p + ggplot2::geom_segment(mapping = ggplot2::aes(x = histDat$x[length(histDat$x)], y = min(yBreaks),
+                                                        xend = histDat$x[length(histDat$x)]), yend = max(yBreaks),
                                  linetype = "dashed") +
 
     ggplot2::scale_x_datetime(name = options$time, breaks = xBreaks, labels = xLabels, limits = range(xBreaks)) +
 
     ggplot2::scale_y_continuous(name = options$dependent, breaks = yBreaks, limits = range(yBreaks))
-  
+
   p <- jaspGraphs::themeJasp(p)
   p <- p + ggplot2::theme(plot.margin = ggplot2::margin(0, 15, 0, 0))
 
@@ -1016,9 +1014,9 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
 
 .prophetCreateCovariatePlotContainer <- function(jaspResults, dataset, options, ready) {
   if (!ready) return()
-  
-  prophetModelResults <- jaspResults[["prophetResults"]][["prophetModelResults"]]$object
-  
+
+  prophetModelResults <- jaspResults[["prophetResults"]][["object"]][["prophetModelResults"]]
+
   prophetCovariatePlots <- createJaspContainer(title = gettext("Covariate Plots"))
   prophetCovariatePlots$dependOn(c("covariatePlots", "covariatePlotsShow"))
   prophetCovariatePlots$position <- 7
@@ -1028,9 +1026,9 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
       .prophetCreateCovariatePlot(prophetCovariatePlots, dataset, cov, prophetModelResults, options)
     }
   }
-  
+
   jaspResults[["prophetMainContainer"]][["prophetCovariatePlots"]] <- prophetCovariatePlots
-  
+
   return()
 }
 
@@ -1065,7 +1063,7 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
   xLabels <- attr(xBreaks, "labels")
   yBreaks <- pretty(y)
 
-  p <- p + 
+  p <- p +
     ggplot2::scale_x_datetime(name = options$time, breaks = xBreaks, labels = xLabels, limits = range(xBreaks))
 
   if (mode == "multiplicative") {
@@ -1078,7 +1076,7 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
                                          breaks = yBreaks,
                                          limits = range(yBreaks))
   }
-  
+
   p <- jaspGraphs::themeJasp(p)
   p <- p + ggplot2::theme(plot.margin = ggplot2::margin(0, 15, 0, 0))
 
@@ -1088,16 +1086,16 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
 .prophetCreatePerformancePlots <- function(jaspResults, options, ready) {
   if (!ready || !options$crossValidation) return()
 
-  prophetEvaluationResults <- jaspResults[["prophetResults"]][["prophetEvaluationResults"]]$object
-  
+  prophetEvaluationResults <- jaspResults[["prophetResults"]][["object"]][["prophetEvaluationResults"]]
+
   prophetPerformancePlots <- createJaspContainer(gettext("Performance Plots"))
   prophetPerformancePlots$dependOn(.prophetEvaluationDependencies())
   prophetPerformancePlots$position <- 8
-  
+
   if(options$performancePlotsMse)  .prophetCreatePerformancePlotMse( prophetPerformancePlots, options, prophetEvaluationResults)
   if(options$performancePlotsRmse) .prophetCreatePerformancePlotRmse(prophetPerformancePlots, options, prophetEvaluationResults)
   if(options$performancePlotsMape) .prophetCreatePerformancePlotMape(prophetPerformancePlots, options, prophetEvaluationResults)
-  
+
   jaspResults[["prophetMainContainer"]][["prophetEvaluationPlots"]] <- prophetPerformancePlots
 
   return()
@@ -1105,48 +1103,48 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
 
 .prophetCreatePerformancePlotMse <- function(prophetPerformancePlots, options, prophetEvaluationResults) {
   if (!is.null(prophetPerformancePlots[["prophetPerformancePlotMse"]])) return()
-  
+
   prophetPerformancePlotMse <- createJaspPlot(title = gettext("MSE"), height = 320, width = 480)
   prophetPerformancePlotMse$dependOn(c("performancePlotsMse"))
-  
+
   prophetPerformancePlotMse$plotObject <- .prophetPerformancePlotFill(prophetEvaluationResults, options, type = "mse")
-  
+
   prophetPerformancePlots[["prophetPerformancePlotMse"]] <- prophetPerformancePlotMse
-  
+
   return()
 }
 
 .prophetCreatePerformancePlotRmse <- function(prophetPerformancePlots, options, prophetEvaluationResults) {
   if (!is.null(prophetPerformancePlots[["prophetPerformancePlotRmse"]])) return()
-  
+
   prophetPerformancePlotRmse <- createJaspPlot(title = gettext("RMSE"), height = 320, width = 480)
   prophetPerformancePlotRmse$dependOn(c("performancePlotsRmse"))
-  
+
   prophetPerformancePlotRmse$plotObject <- .prophetPerformancePlotFill(prophetEvaluationResults, options, type = "rmse")
-  
+
   prophetPerformancePlots[["prophetPerformancePlotRmse"]] <- prophetPerformancePlotRmse
-  
+
   return()
 }
 
 .prophetCreatePerformancePlotMape <- function(prophetPerformancePlots, options, prophetEvaluationResults) {
   if (!is.null(prophetPerformancePlots[["prophetPerformancePlotMape"]])) return()
-  
+
   prophetPerformancePlotMape <- createJaspPlot(title = gettext("MAPE"), height = 320, width = 480)
   prophetPerformancePlotMape$dependOn(c("performancePlotsMape"))
-  
+
   prophetPerformancePlotMape$plotObject <- .prophetPerformancePlotFill(prophetEvaluationResults, options, type = "mape")
-  
+
   prophetPerformancePlots[["prophetPerformancePlotMape"]] <- prophetPerformancePlotMape
-  
+
   return()
 }
 
 .prophetPerformancePlotFill <- function(prophetEvaluationResults, options, type) {
-  
+
   sampleDat <- prophet::performance_metrics(prophetEvaluationResults, metrics = type, rolling_window = -1)
   meanDat   <- prophet::performance_metrics(prophetEvaluationResults, metrics = type, rolling_window = 0)
-  
+
   if (options$crossValidationUnit == "weeks") {
     sampleDat$horizon <- sampleDat$horizon / 7
     meanDat$horizon   <- meanDat$horizon / 7
@@ -1159,49 +1157,49 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
 
   xBreaks <- pretty(sampleDat$horizon)
   yBreaks <- pretty(sampleDat[[type]])
-  
+
   p <- ggplot2::ggplot(data = sampleDat, mapping = ggplot2::aes_string(x = "horizon", y = type)) +
-  
+
     ggplot2::geom_point(size = 3, color = "grey") +
-  
+
     ggplot2::geom_line(data = meanDat, color = "darkred", size = 1.25) +
 
     ggplot2::scale_x_continuous(name = gettext("Horizon"), breaks = xBreaks, limits = range(xBreaks)) +
 
     ggplot2::scale_y_continuous(name = gettext(toupper(type)), breaks = yBreaks, limits = range(yBreaks))
-  
+
   p <- jaspGraphs::themeJasp(p)
-  
+
   return(p)
 }
 
 .prophetCreateParameterPlots <- function(jaspResults, options, ready) {
   if (!ready) return()
 
-  prophetModelResults <- jaspResults[["prophetResults"]][["prophetModelResults"]]$object
-  
+  prophetModelResults <- jaspResults[["prophetResults"]][["object"]][["prophetModelResults"]]
+
   prophetParameterPlots <- createJaspContainer(gettext("Parameter Plots"))
   prophetParameterPlots$position <- 9
-  
-  if(options$parameterPlotsDelta) 
+
+  if(options$parameterPlotsDelta)
     .prophetCreateParameterPlotDelta(prophetParameterPlots, options, prophetModelResults)
 
-  if(options$parameterPlotsMarginalDistributions && options$estimation == "mcmc") 
+  if(options$parameterPlotsMarginalDistributions && options$estimation == "mcmc")
     .prophetCreateParameterPlotMarginal(prophetParameterPlots, options, prophetModelResults)
-  
+
   jaspResults[["prophetMainContainer"]][["prophetParameterPlots"]] <- prophetParameterPlots
 }
 
 .prophetCreateParameterPlotDelta <- function(prophetParameterPlots, options, prophetModelResults) {
   if (!is.null(prophetParameterPlots[["prophetParameterPlotDelta"]])) return()
-  
+
   prophetParameterPlotDelta <- createJaspPlot(title = gettext("Changepoint Plot"), height = 320, width = 480)
   prophetParameterPlotDelta$dependOn(c("parameterPlotsDelta"))
-  
+
   prophetParameterPlotDelta$plotObject <- .prophetParameterPlotDeltaFill(prophetModelResults, options)
-  
+
   prophetParameterPlots[["prophetParameterPlotDelta"]] <- prophetParameterPlotDelta
-  
+
   return()
 }
 
@@ -1210,50 +1208,50 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
                     map  = as.numeric(prophetModelResults[["params"]][["delta"]]),
                     mcmc = as.numeric(apply(prophetModelResults[["params"]][["delta"]], 2, mean)))
   cps     <- as.POSIXct(prophetModelResults$changepoints)
-  
+
   xBreaks <- pretty(cps)
   xLabels <- attr(xBreaks, "labels")
   yBreaks <- pretty(deltas)
-  
+
   p <- ggplot2::ggplot(data = data.frame(x = cps, y = deltas), mapping = ggplot2::aes(x = x, y = y)) +
-  
+
     ggplot2::geom_point(size = 3, color = "grey") +
 
     ggplot2::scale_x_datetime(name = options$time, breaks = xBreaks, labels = xLabels, limits = range(xBreaks)) +
 
     ggplot2::scale_y_continuous(name = gettext("Change in growth rate"), breaks = yBreaks, limits = range(yBreaks))
-  
+
   p <- jaspGraphs::themeJasp(p)
   p <- p + ggplot2::theme(plot.margin = ggplot2::margin(0, 15, 0, 0))
-  
+
   return(p)
 }
 
 .prophetCreateParameterPlotMarginal <- function(prophetParameterPlots, options, prophetModelResults) {
   if (!is.null(prophetParameterPlots[["prophetParameterPlotMarginal"]])) return()
-  
+
   prophetParameterPlotMarginal <- createJaspContainer(title = gettext("Posterior Distributions"))
-  
+
   parNames <- c("k", "m", "sigma_obs")
   parTitles <- c(gettext("Growth rate"), gettext("Offset"), gettext("Residual variance"))
-  
+
   marginalPlotList <- list()
-  
+
   for (i in 1:length(parNames)) {
     marginalPlotList[[i]] <- createJaspPlot(title = parTitles[i], height = 320, width = 480)
-    
-    marginalPlotList[[i]]$plotObject <- .prophetParameterPlotMarginalFill(prophetModelResults, 
-                                                                         options, 
-                                                                         parNames[i], 
+
+    marginalPlotList[[i]]$plotObject <- .prophetParameterPlotMarginalFill(prophetModelResults,
+                                                                         options,
+                                                                         parNames[i],
                                                                          parTitles[i])
-    
+
     prophetParameterPlotMarginal[[parNames[i]]] <- marginalPlotList[[i]]
   }
-  
+
   prophetParameterPlotMarginal$dependOn(c("parameterPlotsMarginalDistributions", "parameterPlotsCredibleIntervalWidth"))
-  
+
   prophetParameterPlots[["prophetParameterPlotMarginal"]] <- prophetParameterPlotMarginal
-  
+
   return()
 }
 
@@ -1262,31 +1260,31 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
   dens    <- density(samples)
   x       <- dens$x
   y       <- dens$y
-  
+
   lvl     <- (1-options[["parameterPlotsCredibleIntervalWidth"]])/2
   cri     <- stats::quantile(samples, prob = c(lvl, 1-lvl))
-  
+
   xBreaks    <- pretty(range(x))
   yBreaks    <- pretty(c(0, 1.15*max(y)))
   yBarPos    <- 0.9*yBreaks[length(yBreaks)]
   yBarHeight <- 0.05*yBreaks[length(yBreaks)]
-  
+
   p <- ggplot2::ggplot() +
-  
+
     ggplot2::geom_line(data = data.frame(x = x, y = y),
                        mapping = ggplot2::aes(x = x, y = y),
                        size = 1.25) +
-  
+
     ggplot2::geom_errorbarh(data = data.frame(xmin = cri[1], xmax = cri[2], y = yBarPos),
                             mapping = ggplot2::aes(xmin = xmin, xmax = xmax, y = y),
                             height = yBarHeight) +
-  
+
     ggplot2::scale_x_continuous(name = parTitle, breaks = xBreaks, limits = range(xBreaks)) +
 
     ggplot2::scale_y_continuous(name = gettext("Density"), breaks = yBreaks, limits = range(yBreaks))
-  
+
   p <- jaspGraphs::themeJasp(p)
-  
+
   return(p)
 }
 
@@ -1296,4 +1294,15 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
 
   propRes <- options$seasonalities[[which(sapply(options$seasonalities, function(s) encodeColNames(s[["name"]]) == name))]][[prop]]
   return(propRes)
+}
+
+# helpers ----
+.prophetIntervalLevels <- function(options, what = c("credible", "prediction")) {
+  what <- match.arg(what)
+  criLevel <- (1-options[["summaryCredibleIntervalWidth"]])/2
+  criLevel <- switch(what,
+                     credible   = (1-options[["summaryCredibleIntervalWidth"]])/2,
+                     prediction = (1-options[["predictionIntervalWidth"]])/2)
+
+  return(c(criLevel, 1-criLevel))
 }

--- a/R/prophet.R
+++ b/R/prophet.R
@@ -40,7 +40,6 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
   .prophetCreateCovariatePlotContainer(  jaspResults, dataset, options, ready)
   .prophetCreatePerformancePlots(        jaspResults, options, ready)
   .prophetCreateParameterPlots(          jaspResults, options, ready)
-  return()
 
   return()
 }
@@ -1209,9 +1208,12 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
 }
 
 .prophetParameterPlotDeltaFill <- function(prophetModelResults, options) {
-  deltas  <- switch(options$estimation,
-                    map  = as.numeric(prophetModelResults[["params"]][["delta"]]),
-                    mcmc = as.numeric(apply(prophetModelResults[["params"]][["delta"]], 2, mean)))
+  if(options[["estimation"]] == "map") {
+    deltas <- as.numeric(prophetModelResults[["params"]][["delta"]])
+  } else {
+    deltas <- prophetModelResults[["modelSummary"]]
+    deltas <- as.numeric(deltas[startsWith(rownames(deltas), "delta"), "mean"])
+  }
   cps     <- as.POSIXct(prophetModelResults$changepoints)
 
   xBreaks <- pretty(cps)
@@ -1253,7 +1255,7 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
     prophetParameterPlotMarginal[[parNames[i]]] <- marginalPlotList[[i]]
   }
 
-  prophetParameterPlotMarginal$dependOn(c("parameterPlotsMarginalDistributions", "parameterPlotsCredibleIntervalWidth"))
+  prophetParameterPlotMarginal$dependOn(c("parameterPlotsMarginalDistributions"))
 
   prophetParameterPlots[["prophetParameterPlotMarginal"]] <- prophetParameterPlotMarginal
 

--- a/inst/qml/Prophet.qml
+++ b/inst/qml/Prophet.qml
@@ -196,7 +196,7 @@ Form
 				}
 				CIField
 				{
-					name: "summaryCredibleIntervalWidth"
+					name: "credibleIntervalWidth"
 					label: qsTr("Credible interval level")
 					visible: mcmc.checked
 					defaultValue: 95

--- a/inst/qml/Prophet.qml
+++ b/inst/qml/Prophet.qml
@@ -7,7 +7,7 @@ import JASP				1.0
 Form
 {
 	VariablesForm
-	{	
+	{
 		preferredHeight: 400 * preferencesModel.uiScale
 		AvailableVariablesList	{ name: "allVariablesList" }
 		AssignedVariablesList	{ name: "dependent"; title: qsTr("Dependent Variable");	suggestedColumns: ["scale"]; singleVariable: true													}
@@ -18,7 +18,7 @@ Form
 		AssignedVariablesList	{ name: "covariates"; title: qsTr("Covariates"); suggestedColumns: ["scale"];																				}
 		AssignedVariablesList	{ name: "historyIndicator"; title: qsTr("Include in Training"); suggestedColumns: ["scale"]; singleVariable: true											}
 	}
-	
+
 	columns: 3
 
 	CheckBox
@@ -26,13 +26,13 @@ Form
 		name: "historyPlot"
 		label: qsTr("History plot")
 		id: histplot
-		
+
 		RadioButtonGroup
 		{
 			name: "historyPlotShow"
 			visible: histplot.checked
 			columns: 3
-			
+
 			RadioButton
 			{
 				value: "points"
@@ -50,12 +50,12 @@ Form
 				label: qsTr("Both")
 			}
 		}
-		
+
 		CheckBox
 		{
 			name: "historyPlotRange"
 			label: qsTr("Plot time interval")
-			
+
 			Group
 			{
 				TextField
@@ -75,7 +75,7 @@ Form
 			}
 		}
 	}
-	
+
 	RadioButtonGroup
 	{
 		name: "growth"
@@ -92,7 +92,7 @@ Form
 			value: "logistic"
 			label: qsTr("Logistic")
 			childrenOnSameRow: false
-			
+
 			Group
 			{
 				DoubleField
@@ -152,7 +152,7 @@ Form
 					decimals: 3
 				}
 			}
-			
+
 			RadioButtonGroup
 			{
 				name: "estimation"
@@ -203,7 +203,7 @@ Form
 				}
 			}
 		}
-		
+
 		VariablesList
 		{
 			name: "assignedCovariates"
@@ -211,7 +211,7 @@ Form
 			listViewType: JASP.AssignedVariables
 			preferredHeight: 100 * preferencesModel.uiScale
 			draggable: false
-			
+
 			title: qsTr("Covariates                                                  Normal prior σ²                 Standardize                 Mode")
 			rowComponent: Row
 			{
@@ -238,11 +238,11 @@ Form
 				}
 			}
 		}
-		
+
 		Group
 		{
 			title: qsTr("Seasonalities")
-			
+
 			ColumnLayout
 			{
 				spacing: 0 * preferencesModel.uiScale
@@ -264,7 +264,7 @@ Form
 						{
 							Layout.preferredWidth: 100 * preferencesModel.uiScale
 							spacing: 4 * preferencesModel.uiScale
-							
+
 							TextField
 							{
 								name: "name"
@@ -276,7 +276,7 @@ Form
 						{
 							Layout.preferredWidth: 45 * preferencesModel.uiScale
 							spacing: 4 * preferencesModel.uiScale
-							
+
 							DoubleField
 							{
 								name: "period"
@@ -287,7 +287,7 @@ Form
 						{
 							Layout.preferredWidth: 80 * preferencesModel.uiScale
 							spacing: 4 * preferencesModel.uiScale
-							
+
 							DropDown
 							{
 								name: "unit"
@@ -307,7 +307,7 @@ Form
 						{
 							Layout.preferredWidth: 100 * preferencesModel.uiScale
 							spacing: 4 * preferencesModel.uiScale
-							
+
 							DoubleField
 							{
 								name: "priorSigma"
@@ -318,7 +318,7 @@ Form
 						{
 							Layout.preferredWidth: 70 * preferencesModel.uiScale
 							spacing: 4 * preferencesModel.uiScale
-							
+
 							IntegerField
 							{
 								name: "fourierOrder"
@@ -329,7 +329,7 @@ Form
 						{
 							Layout.preferredWidth: 122 * preferencesModel.uiScale
 							spacing: 4 * preferencesModel.uiScale
-							
+
 							DropDown
 							{
 								name: "mode"
@@ -346,7 +346,7 @@ Form
 			}
 		}
 	}
-	
+
 	Section
 	{
 		title: qsTr("Prediction")
@@ -429,11 +429,11 @@ Form
 			save:	true
 		}
 	}
-	
+
 	Section
 	{
 		title: qsTr("Evaluation")
-		
+
 		CheckBox
 		{
 			name: "crossValidation"
@@ -476,7 +476,7 @@ Form
 				}
 			}
 		}
-		
+
 		CheckBox
 		{
 			name: "performanceMetrics"
@@ -499,13 +499,13 @@ Form
 				label: qsTr("Mean absolute percentage error (MAPE)")
 			}
 		}
-		
+
 		CheckBox
 		{
 			name: "changePointTable"    ; label: qsTr("Changepoint table")
 		}
 	}
-	
+
 	Section
 	{
 		title: qsTr("Plots")
@@ -546,7 +546,7 @@ Form
 					{
 						name: "forecastPlotsOverallRange"
 						label: qsTr("Plot time interval")
-						
+
 						TextField
 						{
 							name: "forecastPlotsOverallStart"
@@ -577,7 +577,7 @@ Form
 				{
 					name: "forecastPlotsTrendRange"
 					label: qsTr("Plot time interval")
-					
+
 					Group
 					{
 						TextField
@@ -605,7 +605,7 @@ Form
 			AvailableVariablesList { name: "seasonalityNames"; title: qsTr("Seasonalities"); source: "seasonalities.name"	}
 			AssignedVariablesList { name: "seasonalityPlots"; title: qsTr("Seasonality Plots")								}
 		}
-		
+
 		VariablesForm
 		{
 			preferredHeight: 0.5 * jaspTheme.smallDefaultVariablesFormHeight
@@ -670,12 +670,6 @@ Form
 					name: "parameterPlotsMarginalDistributions"
 					label: qsTr("Posterior distributions")
 					enabled: mcmc.checked
-					CIField
-					{
-						name: "parameterPlotsCredibleIntervalWidth"
-						label: qsTr("Credible interval level")
-						defaultValue: 95
-					}
 				}
 			}
 		}

--- a/jaspProphet.Rproj
+++ b/jaspProphet.Rproj
@@ -1,0 +1,20 @@
+Version: 1.0
+
+RestoreWorkspace: No
+SaveWorkspace: No
+AlwaysSaveHistory: No
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.sourcee

--- a/tests/testthat/test-prophet.R
+++ b/tests/testthat/test-prophet.R
@@ -1,6 +1,6 @@
 context("Prophet")
 
-# Make sure to run the test for plots with date axes on a system with English language 
+# Make sure to run the test for plots with date axes on a system with English language
 # because months and weekdays will be displayed depending on that
 
 dateTimeVarNames <- c("dateYear", "dateWeek", "dateDay", "timeHour", "timeMinute", "timeSecond")
@@ -12,7 +12,7 @@ test_that("Posterior Summary Table results match (linear)", {
   options$time <- "dateYear"
   options$mcmcSamples <- 10
   options$predictionSavePath <- ""
-  
+
   for (i in 1:6) {
     options$time <- dateTimeVarNames[i]
     set.seed(1)
@@ -24,7 +24,7 @@ test_that("Posterior Summary Table results match (linear)", {
                                         0.113226988344312, "Offset (m)", 1, 0.0831938284838563, 20,
                                         0.252718078792628, 20, 0.374623449591915, 0.573723365352864,
                                         "Residual variance (sigma)", 1, 0.2235178416768, 20, 0.942133582100974
-                                   )) 
+                                   ))
   }
 })
 
@@ -36,7 +36,7 @@ test_that("Posterior Summary Table results match (logistic)", {
   options$mcmcSamples <- 10
   options$growth <- "logistic"
   options$predictionSavePath <- ""
-  
+
   for (i in 1:6) {
     options$time <- dateTimeVarNames[i]
     options$periodicalPredictionUnit <- dateTimeUnits[i]
@@ -168,7 +168,7 @@ test_that("Parameter Estimates Table results match (MAP)", {
     list(-0.165701104700655, 0.0288912230542516, 0.315932056357582))
 
   # Does currently not work on Mac
-  
+
   testthat::skip_on_os(c("mac", "linux"))
 
   options$capacity <- "contGamma"
@@ -189,7 +189,7 @@ test_that("Changepoint Posterior Summary Table results match (automatic)", {
   options$changePointTable <- TRUE
   options$maxChangepoints <- 3
   options$predictionSavePath <- ""
-  
+
   testList <- list(
     list("2044-01-01", -0.102577025508582, 0.000747031374094744, 0.0796092516712301,
        0.0823103488296078, "2071-01-01", -0.183201673409137, -0.0278855575007965,
@@ -218,7 +218,7 @@ test_that("Changepoint Posterior Summary Table results match (automatic)", {
        -0.183203980495524, -0.0278911157685207, 0.0596231040299391,
        0.0502187402975552, "2018-01-01 00:01:19", -0.0288794834942642,
        0.0549111163785803, 0.10334759494585, 0.226317381592537))
-  
+
   for (i in 1:6) {
     options$time <- dateTimeVarNames[i]
     set.seed(1)
@@ -262,7 +262,7 @@ test_that("Changepoint Posterior Summary Table results match (MAP)", {
   options$changePointTable <- TRUE
   options$maxChangepoints <- 3
   options$predictionSavePath <- ""
-  
+
   testList <- list(
     list(-4.6571455544865e-09, "2044-01-01", -5.36239276854111e-10, "2071-01-01",
        6.72791321806394e-10, "2097-01-01"),
@@ -276,7 +276,7 @@ test_that("Changepoint Posterior Summary Table results match (MAP)", {
        "2018-01-01 00:53:00", 4.11746384728716e-08, "2018-01-01 01:19:00"),
     list(1.40971557048972e-08, "2018-01-01 00:00:26", 7.14102900553978e-10,
        "2018-01-01 00:00:53", 4.11746384728716e-08, "2018-01-01 00:01:19"))
-  
+
   for (i in 1:6) {
     options$time <- dateTimeVarNames[i]
     set.seed(1)
@@ -299,7 +299,7 @@ test_that("Simulated Historical Forecasts Table results match", {
   options$performanceMetricsRmse <- TRUE
   options$performanceMetricsMape <- TRUE
   options$predictionSavePath <- ""
-  
+
   for (i in 2:6) { # except years because it doesn't work for cross validation
     options$time <- dateTimeVarNames[i]
     options$periodicalPredictionUnit <- dateTimeUnits[i]
@@ -499,7 +499,7 @@ test_that("Performance Plots match", {
   options$performancePlotsMse <- TRUE
   options$performancePlotsRmse <- TRUE
   options$performancePlotsMape <- TRUE
-  
+
   for (i in 2:6) { # except years because it doesn't work for cross validation
     options$time <- dateTimeVarNames[i]
     options$periodicalPredictionUnit <- dateTimeUnits[i]


### PR DESCRIPTION
Removes stanfit and mcmc objects from state. As a consequence, model fit, predictions/forecasts, and cross-validation/evaluation share the same state. This means that for example changing the horizon of simulated historical forecast will trigger sampling the model and predictions anew. The alternative would be to recreate whatever the prophet package does inside `predict.prophet()`, `make_future_dataframe()`, and `cross_validation()` without relying on the stanfit object, but I did not do this as it would require some more figuring out for which we do not have time atm.

I am currently running the example analysis to confirm that it sufficiently reduces the size of the jasp file. I will post the outcome here once the analysis finishes running. 