### PR TITLE
Make prediction optional

### DIFF
--- a/R/prophet.R
+++ b/R/prophet.R
@@ -752,7 +752,7 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
 }
 
 .prophetCreateForecastPlots <- function(jaspResults, dataset, options, ready) {
-  if (!ready || is.null(jaspResults[["prophetResults"]][["object"]][["prophetPredictionResults"]])) return()
+  if (!ready) return()
 
   prophetModelResults      <- jaspResults[["prophetResults"]][["object"]][["prophetModelResults"]]
   prophetPredictionResults <- jaspResults[["prophetResults"]][["object"]][["prophetPredictionResults"]]
@@ -760,6 +760,15 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
   prophetForecastPlots <- createJaspContainer(title = gettext("Forecast Plots"))
   prophetForecastPlots$dependOn(.prophetPredictionDependencies())
   prophetForecastPlots$position <- 5
+
+  if((options[["forecastPlotsOverall"]] || options [["forecastPlotsTrend"]]) && is.null(prophetPredictionResults)) {
+
+    errorTable <- createJaspTable()
+    errorTable$setError(gettext("Cannot draw forecast plots; no forecasts computed."))
+    prophetForecastPlots[["errorTable"]] <- errorTable
+    jaspResults[["prophetMainContainer"]][["prophetForecastPlots"]] <- prophetForecastPlots
+    return()
+  }
 
   if (options$forecastPlotsOverall) .prophetCreateOverallForecastPlot(prophetForecastPlots, dataset, options, prophetPredictionResults)
   if (options$forecastPlotsTrend)   .prophetCreateTrendForecastPlot(prophetForecastPlots, dataset, options, prophetPredictionResults)

--- a/R/prophet.R
+++ b/R/prophet.R
@@ -239,8 +239,12 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
     prophetModelFullResults  <- .prophetModelResultsHelper(dataset, options)
     prophetResults[["prophetModelResults"]] <- .prophetModelResultsReduce(prophetModelFullResults, options)
 
+    if ((options[["predictionType"]] == "periodicalPrediction" && options[["periodicalPredictionNumber"]] > 0) ||
+    (options[["predictionType"]] == "nonperiodicalPrediction") && options[["forecastPlotsTrendStart"]] != "" &&
+    options[["forecastPlotsTrendEnd"]] != "") {
     prophetPredictionResults <- .prophetPredictionResultsHelper(dataset, options, prophetModelFullResults)
     prophetResults[["prophetPredictionResults"]] <- prophetPredictionResults
+    }
 
     if (options[["crossValidation"]]) {
       prophetEvaluationResults <- .prophetEvaluationResultsHelper(dataset, options, prophetModelFullResults)
@@ -748,7 +752,7 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
 }
 
 .prophetCreateForecastPlots <- function(jaspResults, dataset, options, ready) {
-  if (!ready) return()
+  if (!ready || is.null(jaspResults[["prophetResults"]][["object"]][["prophetPredictionResults"]])) return()
 
   prophetModelResults      <- jaspResults[["prophetResults"]][["object"]][["prophetModelResults"]]
   prophetPredictionResults <- jaspResults[["prophetResults"]][["object"]][["prophetPredictionResults"]]

--- a/tests/testthat/test-prophet.R
+++ b/tests/testthat/test-prophet.R
@@ -12,6 +12,7 @@ test_that("Posterior Summary Table results match (linear)", {
   options$time <- "dateYear"
   options$mcmcSamples <- 10
   options$predictionSavePath <- ""
+  options$maxChangepoints <- 25
 
   for (i in 1:6) {
     options$time <- dateTimeVarNames[i]
@@ -36,6 +37,7 @@ test_that("Posterior Summary Table results match (logistic)", {
   options$mcmcSamples <- 10
   options$growth <- "logistic"
   options$predictionSavePath <- ""
+  options$maxChangepoints <- 25
 
   for (i in 1:6) {
     options$time <- dateTimeVarNames[i]
@@ -59,6 +61,7 @@ test_that("Posterior Summary Table results match (covariates-linear)", {
   options$covariates <- list("contcor1", "contcor2")
   options$historyIndicator <- "histIdx"
   options$mcmcSamples <- 10
+  options$maxChangepoints <- 25
   options$assignedCovariates <- list(list(
     variable = "contcor1",
     priorSigma = 10,
@@ -90,6 +93,7 @@ test_that("Posterior Summary Table results match (covariates-logistic)", {
   options$historyIndicator <- "histIdx"
   options$mcmcSamples <- 10
   options$growth <- "logistic"
+  options$maxChangepoints <- 25
   options$assignedCovariates <- list(list(
     variable = "contcor1",
     priorSigma = 10,
@@ -123,6 +127,7 @@ test_that("Posterior Summary Table results match (minimum-logistic)", {
      options$mcmcSamples <- 10
      options$growth <- "logistic"
      options$predictionSavePath <- ""
+     options$maxChangepoints <- 25
      set.seed(1)
      results <- jaspTools::runAnalysis("Prophet", "prophetTest.csv", options)
      table <- results[["results"]][["prophetMainContainer"]][["collection"]][["prophetMainContainer_prophetTable"]][["data"]]
@@ -143,6 +148,7 @@ test_that("Posterior Summary Table results match (constant-logistic)", {
   options$mcmcSamples <- 10
   options$growth <- "logistic"
   options$predictionSavePath <- ""
+  options$maxChangepoints <- 25
   set.seed(1)
   results <- jaspTools::runAnalysis("Prophet", "prophetTest.csv", options)
   table <- results[["results"]][["prophetMainContainer"]][["collection"]][["prophetMainContainer_prophetTable"]][["data"]]
@@ -161,6 +167,7 @@ test_that("Parameter Estimates Table results match (MAP)", {
   options$predictionIntervalSamples <- 10
   options$estimation <- "map"
   options$predictionSavePath <- ""
+  options$maxChangepoints <- 25
   set.seed(1)
   results <- jaspTools::runAnalysis("Prophet", "prophetTest.csv", options)
   table <- results[["results"]][["prophetMainContainer"]][["collection"]][["prophetMainContainer_prophetTable"]][["data"]]
@@ -299,6 +306,7 @@ test_that("Simulated Historical Forecasts Table results match", {
   options$performanceMetricsRmse <- TRUE
   options$performanceMetricsMape <- TRUE
   options$predictionSavePath <- ""
+  options$maxChangepoints <- 25
 
   for (i in 2:6) { # except years because it doesn't work for cross validation
     options$time <- dateTimeVarNames[i]
@@ -332,6 +340,7 @@ test_that("Simulated Historical Forecasts Table results match (MAP)", {
   options$performanceMetricsMape <- TRUE
   options$estimation <- "map"
   options$predictionSavePath <- ""
+  options$maxChangepoints <- 25
 
   for (i in 2:6) { # except years because it doesn't work for cross validation
     options$time <- dateTimeVarNames[i]
@@ -376,6 +385,7 @@ test_that("Overall Forecast Plot matches", {
   options$forecastPlotsOverall <- TRUE
   options$forecastPlotsOverallAddData <- TRUE
   options$predictionSavePath <- ""
+  options$maxChangepoints <- 25
 
   for (i in 1:6) {
     options$time <- dateTimeVarNames[i]
@@ -408,6 +418,7 @@ test_that("Trend Forecast Plot matches", {
   options$forecastPlotsTrend <- TRUE
   options$predictionSavePath <- ""
   set.seed(1)
+  options$maxChangepoints <- 25
   results <- jaspTools::runAnalysis("Prophet", "prophetTest.csv", options)
   plotName <- results[["results"]][["prophetMainContainer"]][["collection"]][["prophetMainContainer_prophetForecastPlots"]][["collection"]][["prophetMainContainer_prophetForecastPlots_prophetTrendForecastPlot"]][["data"]]
   testPlot <- results[["state"]][["figures"]][[plotName]][["obj"]]
@@ -420,6 +431,7 @@ test_that("Seasonality Plot matches", {
   options$mcmcSamples <- 10
   options$seasonalityPlots <- "custom"
   options$predictionSavePath <- ""
+  options$maxChangepoints <- 25
 
   for (i in 1:6) {
     options$time <- dateTimeVarNames[i]
@@ -499,6 +511,7 @@ test_that("Performance Plots match", {
   options$performancePlotsMse <- TRUE
   options$performancePlotsRmse <- TRUE
   options$performancePlotsMape <- TRUE
+  options$maxChangepoints <- 25
 
   for (i in 2:6) { # except years because it doesn't work for cross validation
     options$time <- dateTimeVarNames[i]
@@ -527,6 +540,7 @@ test_that("Changepoint Plot matches", {
   options$mcmcSamples <- 10
   options$parameterPlotsDelta <- TRUE
   options$predictionSavePath <- ""
+  options$maxChangepoints <- 25
 
   for (i in 1:6) {
     options$time <- dateTimeVarNames[i]
@@ -548,6 +562,7 @@ test_that("Parameter Plots match", {
   options$parameterPlotsMarginalDistributions <- TRUE
   options$predictionSavePath <- ""
   set.seed(1)
+  options$maxChangepoints <- 25
   results <- jaspTools::runAnalysis("Prophet", "prophetTest.csv", options)
 
   plotName <- results[["results"]][["prophetMainContainer"]][["collection"]][["prophetMainContainer_prophetParameterPlots"]][["collection"]][["prophetMainContainer_prophetParameterPlots_prophetParameterPlotMarginal"]][["collection"]][["prophetMainContainer_prophetParameterPlots_prophetParameterPlotMarginal_k"]][["data"]]


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/2023

Now the module only makes future predictions if the prediction horizon is correctly specified (i.e prediction period above 0 for periodical prediction or the date values are not empty for non periodical prediction) 