### PR TITLE
Fix Prophet option to save predictions

### DIFF
--- a/R/prophet.R
+++ b/R/prophet.R
@@ -469,7 +469,7 @@ Prophet <- function(jaspResults, dataset = NULL, options) {
   }
 
   if (options$predictionSavePath != "") {
-    write.csv(jaspResults[["prophetResults"]][["object"]][["prophetModelResults"]],
+    write.csv(jaspResults[["prophetResults"]][["object"]][["prophetPredictionResults"]],
               file = options$predictionSavePath,
               row.names = FALSE)
     predSavePath[["object"]] <- TRUE


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/2201

The problem was that the model in  `prophetModelResults` was saved instead of the actual predictions saved in `prophetPredictionResults`. Should be fixed now.